### PR TITLE
Update section title for SANY improvements

### DIFF
--- a/content/grants/grant-recipients.md
+++ b/content/grants/grant-recipients.md
@@ -25,7 +25,7 @@ The next step is to integrate the proof decomposition actions into the proof obl
 
 ## 2024
 
-### PlusCal Extensions, Unicode Adoption, and TLC Improvements
+### PlusCal Extensions, Unicode Adoption, and SANY Improvements
 
 **Lead:** Andrew Helwer  
 **Grant:** $93,000


### PR DESCRIPTION
@taylorwaggoner "SANY improvements" would be factually more accurate than "TLC improvements". However, if "PlusCal Extensions, Unicode Adoption, and TLC Improvements" is the official title of the grant proposal, please feel free to keep it as is.